### PR TITLE
Added base classes for actions and frontiers. Removed box actions from action library for levels without boxes

### DIFF
--- a/searchclient/domains/hospital/actions.py
+++ b/searchclient/domains/hospital/actions.py
@@ -15,8 +15,9 @@ from __future__ import annotations
 # pos_add and pos_sub are helper methods for performing element-wise addition and subtractions on positions
 # Ex: Given two positions A = (1, 2) and B = (3, 4), pos_add(A, B) == (4, 6) and pos_sub(B, A) == (2,2)
 from utils import pos_add, pos_sub
-from typing import Union, Tuple
+from typing import Union, Tuple, Protocol
 import domains.hospital.state as h_state
+from abc import abstractmethod
 
 direction_deltas = {
     'N': (-1, 0),
@@ -48,7 +49,26 @@ direction_deltas = {
 
 Position = Tuple[int, int] # Only for type hinting
 
-class NoOpAction:
+class Action(Protocol):
+    name: str
+
+    @abstractmethod
+    def is_applicable(self, agent_index: int, state: h_state.HospitalState) -> bool:
+        ...
+
+    @abstractmethod
+    def result(self, agent_index: int, state: h_state.HospitalState):
+        ...
+    
+    @abstractmethod
+    def conflicts(self, agent_index: int, state: h_state.HospitalState) -> tuple[list[Position], list[Position]]:
+        ...
+
+    def __repr__(self) -> str:
+        return self.name
+
+
+class NoOpAction(Action):
 
     def __init__(self):
         self.name = "NoOp"
@@ -66,11 +86,8 @@ class NoOpAction:
         boxes_moved = []
         return destinations, boxes_moved
 
-    def __repr__(self) -> str:
-        return self.name
 
-
-class MoveAction:
+class MoveAction(Action):
 
     def __init__(self, agent_direction):
         self.agent_delta = direction_deltas.get(agent_direction)
@@ -98,12 +115,8 @@ class MoveAction:
         boxes_moved = []
         return destinations, boxes_moved
 
-    def __repr__(self):
-        return self.name
 
-AnyAction = Union[NoOpAction, MoveAction] # Only for type hinting
-
-class PushAction:
+class PushAction(Action):
 
     def __init__(self, agent_direction, box_direction):
         self.agent_delta = direction_deltas.get(agent_direction)
@@ -137,11 +150,8 @@ class PushAction:
         boxes_moved = [old_box_position]
         return destinations, boxes_moved
 
-    def __repr__(self):
-        return self.name
 
-
-class PullAction:
+class PullAction(Action):
 
     def __init__(self, agent_direction, box_direction):
         self.agent_delta = direction_deltas.get(agent_direction)
@@ -174,9 +184,6 @@ class PullAction:
         destinations = [new_agent_position]
         boxes_moved = [current_box_position]
         return destinations, boxes_moved
-
-    def __repr__(self):
-        return self.name
 
 
 

--- a/searchclient/domains/hospital/state.py
+++ b/searchclient/domains/hospital/state.py
@@ -40,7 +40,7 @@ class HospitalState:
         agent_positions: list[tuple[tuple[int, int], str]],
         box_positions: list[tuple[tuple[int, int], str]],
         parent = None,
-        action: actions.AnyAction = None
+        action: actions.Action = None
     ):
         self.level = level
         self.agent_positions = agent_positions
@@ -92,7 +92,7 @@ class HospitalState:
                self.agent_at(position)[1] == '' and \
                self.box_at(position)[1] == ''
 
-    def extract_plan(self) -> list[actions.AnyAction]:
+    def extract_plan(self) -> list[actions.Action]:
         """Extracts a plan from the search tree by walking backwards through the search tree"""
         reverse_plan = []
         current_node = self
@@ -102,7 +102,7 @@ class HospitalState:
         reverse_plan.reverse()
         return reverse_plan
 
-    def is_conflicting(self, joint_action: list[actions.AnyAction]) -> bool:
+    def is_conflicting(self, joint_action: list[actions.Action]) -> bool:
         """Returns true if any of the individual agent actions in the joint action results in a conflict"""
         # All previously free cells which either an agent or box will move into during the joint action
         destinations = set()
@@ -128,7 +128,7 @@ class HospitalState:
 
         return False
 
-    def result(self, joint_action: list[actions.AnyAction]):
+    def result(self, joint_action: list[actions.Action]):
         """Computes the state resulting from applying a joint action to this state"""
         new_state = HospitalState(self.level, copy.copy(self.agent_positions), copy.copy(self.box_positions),
                                   self, joint_action)
@@ -142,7 +142,7 @@ class HospitalState:
 
         return new_state
 
-    def result_of_plan(self, plan: list[list[actions.AnyAction]]):
+    def result_of_plan(self, plan: list[list[actions.Action]]):
         """Computes the state resulting from applying a sequence of joint actions (a plan) to this state"""
         # If the plan is empty, just return a new copy of the current state
         if len(plan) == 0:
@@ -153,14 +153,14 @@ class HospitalState:
             new_state = new_state.result(joint_action)
         return new_state
 
-    def is_applicable(self, joint_action: list[actions.AnyAction]) -> bool:
+    def is_applicable(self, joint_action: list[actions.Action]) -> bool:
         """Returns whether all individual actions in the joint_action is applicable in this state"""
         for agent_index, action in enumerate(joint_action):
             if not action.is_applicable(agent_index, self):
                 return False
         return True
 
-    def get_applicable_actions(self, action_set: list[list[actions.AnyAction]]):
+    def get_applicable_actions(self, action_set: list[list[actions.Action]]):
         """Returns a list of all applicable joint_action in this state"""
         num_agents = len(self.agent_positions)
 

--- a/searchclient/search_algorithms/graph_search.py
+++ b/searchclient/search_algorithms/graph_search.py
@@ -28,10 +28,10 @@ from domains.hospital.actions import MoveAction
 # actions!) but if it is confusing, you can just ignore it as it is only for documentation
 def graph_search(
         initial_state:      state.HospitalState,
-        action_set:         list[list[actions.AnyAction]],
+        action_set:         list[list[actions.Action]],
         goal_description:   goal_description.HospitalGoalDescription,
         frontier:           bfs.FrontierBFS
-    ) -> tuple[bool, list[list[actions.AnyAction]]]:
+    ) -> tuple[bool, list[list[actions.Action]]]:
     global start_time
 
     # Set start time

--- a/searchclient/search_algorithms/graph_search.py
+++ b/searchclient/search_algorithms/graph_search.py
@@ -19,7 +19,7 @@ from typing import Union
 import domains.hospital.actions as actions
 import domains.hospital.state as state
 import domains.hospital.goal_description as goal_description
-import strategies.bfs as bfs
+import strategies.base as base
 
 from domains.hospital.actions import MoveAction
 
@@ -30,7 +30,7 @@ def graph_search(
         initial_state:      state.HospitalState,
         action_set:         list[list[actions.Action]],
         goal_description:   goal_description.HospitalGoalDescription,
-        frontier:           bfs.FrontierBFS
+        frontier:           base.Frontier
     ) -> tuple[bool, list[list[actions.Action]]]:
     global start_time
 

--- a/searchclient/searchclient.py
+++ b/searchclient/searchclient.py
@@ -99,6 +99,12 @@ if __name__ == '__main__':
 
         # Construct the requested action library
         action_library = DEFAULT_HOSPITAL_ACTION_LIBRARY
+        if initial_state.level.num_boxes == 0: # Remove pull and push actions if there are no boxes
+            action_library = [
+                action for action in action_library 
+                if not isinstance(action, PullAction) \
+                and not isinstance(action, PushAction)
+            ]
 
         # Construct the requested heuristic
         if heuristic_name == 'goalcount':

--- a/searchclient/strategies/base.py
+++ b/searchclient/strategies/base.py
@@ -1,0 +1,31 @@
+from typing import Protocol
+from abc import abstractmethod
+
+import domains.hospital.goal_description as h_goal_description
+import domains.hospital.state as h_state
+
+
+class Frontier(Protocol):
+    @abstractmethod
+    def prepare(self, goal_description: h_goal_description.HospitalGoalDescription) -> None:
+        ...
+
+    @abstractmethod
+    def add(self, state: h_state.HospitalState) -> None:
+        ...
+
+    @abstractmethod
+    def pop(self) -> h_state.HospitalState:
+        ...
+
+    @abstractmethod
+    def is_empty(self) -> bool:
+        ...
+    
+    @abstractmethod
+    def size(self) -> int:
+        ...
+
+    @abstractmethod
+    def contains(self, state: h_state.HospitalState) -> bool:
+        ...

--- a/searchclient/strategies/base.py
+++ b/searchclient/strategies/base.py
@@ -29,3 +29,9 @@ class Frontier(Protocol):
     @abstractmethod
     def contains(self, state: h_state.HospitalState) -> bool:
         ...
+
+    def __len__(self) -> int:
+        return self.size()
+    
+    def __contains__(self, state: h_state.HospitalState) -> bool:
+        return self.contains(state)

--- a/searchclient/strategies/bestfirst.py
+++ b/searchclient/strategies/bestfirst.py
@@ -17,6 +17,7 @@ import itertools
 
 import domains.hospital.goal_description as h_goal_description
 import domains.hospital.state as h_state
+from strategies.base import Frontier
 
 # Here we define a priority queue which allows the priority of elements to be updated in constant time.
 # This priority queue is therefore suitable for usage as the frontier in a best-first search.
@@ -79,7 +80,7 @@ class PriorityQueue:
         return entry[0]
 
 
-class FrontierBestFirst:
+class FrontierBestFirst(Frontier):
 
     def __init__(self):
         self.goal_description = None

--- a/searchclient/strategies/bfs.py
+++ b/searchclient/strategies/bfs.py
@@ -15,8 +15,10 @@ from collections import deque
 
 import domains.hospital.goal_description as h_goal_description
 import domains.hospital.state as h_state
+from strategies.base import Frontier
 
-class FrontierBFS:
+
+class FrontierBFS(Frontier):
 
     def __init__(self):
         # We use both a deque and a set for the BFS implementation.

--- a/searchclient/strategies/dfs.py
+++ b/searchclient/strategies/dfs.py
@@ -14,8 +14,10 @@ from __future__ import annotations
 
 import domains.hospital.goal_description as h_goal_description
 import domains.hospital.state as h_state
+from strategies.base import Frontier
 
-class FrontierDFS:
+
+class FrontierDFS(Frontier):
 
     def __init__(self):
         # Your code here...


### PR DESCRIPTION
Small change to improve type hinting by making base classes for actions and frontiers.

This also reduces redundancy for the actions as every class no longer has to have a __repr__.

For the frontiers, it allows proper type hinting in graph_search and the use of dunder methods. 

Also removed actions which require boxes (Pull, Push) from action_library if the level does not have any boxes. This improves the performance of graph search as less actions have to be checked.